### PR TITLE
Stop showing demo data to signed-in users; make ai-becoming canonical

### DIFF
--- a/.github/workflows/deploy-pratyaksha.yml
+++ b/.github/workflows/deploy-pratyaksha.yml
@@ -26,8 +26,14 @@ on:
   #   branches: [main]
   #   paths: ['Pratyaksha/dashboard/**']
 
+# Canonical URL is https://ai-becoming.web.app (site "ai-becoming" in the
+# social-data-pipeline-and-push Firebase project) — the URL the product is
+# actually used on. FIREBASE_SERVICE_ACCOUNT must be a key for that project
+# with the "Firebase Hosting Admin" role. The site is configured in
+# firebase.ai-becoming.json (Auth remains on the pratyaksha-3f089 project,
+# which already authorizes ai-becoming.web.app).
 env:
-  FIREBASE_PROJECT_ID: pratyaksha-3f089
+  FIREBASE_PROJECT_ID: social-data-pipeline-and-push
 
 jobs:
   deploy-frontend:
@@ -71,7 +77,7 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
         run: |
-          npx firebase-tools deploy --only hosting --project "$FIREBASE_PROJECT_ID" --non-interactive
+          npx firebase-tools deploy --only hosting --project "$FIREBASE_PROJECT_ID" --config firebase.ai-becoming.json --non-interactive
 
       - name: Display URL
-        run: echo "Frontend deployed -> https://pratyaksha-3f089.web.app"
+        run: echo "Frontend deployed -> https://ai-becoming.web.app"

--- a/Pratyaksha/dashboard/firebase.ai-becoming.json
+++ b/Pratyaksha/dashboard/firebase.ai-becoming.json
@@ -1,0 +1,18 @@
+{
+  "hosting": {
+    "site": "ai-becoming",
+    "public": "dist",
+    "ignore": ["firebase.json", "firebase.ai-becoming.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
+    ],
+    "headers": [
+      {
+        "source": "/assets/**",
+        "headers": [
+          { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        ]
+      }
+    ]
+  }
+}

--- a/Pratyaksha/dashboard/src/lib/airtable.ts
+++ b/Pratyaksha/dashboard/src/lib/airtable.ts
@@ -295,17 +295,18 @@ export async function fetchEntries(userId?: string, demoPersona?: string): Promi
   })
 
   if (!response.ok) {
+    // A logged-in user's request failed (network / backend down / 404 no such
+    // user). Surface the error instead of silently showing someone else's demo
+    // data — React Query keeps the last good entries during background
+    // refetches and retries, so a real signed-in user never sees Mario's data.
     console.error(`Failed to fetch entries: ${response.status}`)
-    // Fallback to demo data on error
-    const { getDemoData } = await import("./demoPersonas")
-    return getDemoData("mario")
+    throw new Error(`Failed to fetch entries (${response.status})`)
   }
 
   const data = await response.json()
   if (!data.success || !data.entries) {
     console.error("Invalid response from /api/entries")
-    const { getDemoData } = await import("./demoPersonas")
-    return getDemoData("mario")
+    throw new Error("Invalid response from /api/entries")
   }
 
   return data.entries.map(transformRecord)


### PR DESCRIPTION
## Summary
Fixes the root cause of the "I see Mario's demo entries" issue and makes the deploy target match the URL actually in use.

- **`fetchEntries`**: a **signed-in** user whose `/api/entries` call fails (backend down, CORS, 404 no-such-user) now throws so React Query retries and keeps last-good data — instead of silently rendering **Mario demo** entries. Demo data still shows for **logged-out** visitors (its intended purpose). The original bug: a stale build hitting the dead Cloud Run backend fell through to `getDemoData("mario")`, masking the real problem.
- **Canonical URL → `ai-becoming.web.app`**: added `firebase.ai-becoming.json` and pointed the deploy workflow at the `ai-becoming` site (project `social-data-pipeline-and-push`). Auth stays on `pratyaksha-3f089`, which already authorizes that domain.

## Verified live (in-browser, signed in as the real user)
- `ai-becoming.web.app/logs` shows **235 real entries**, zero demo markers
- `/insights` renders real AI-generated summaries (no paywall)
- `/compare` renders real period comparison (no paywall)
- Direct backend fetch from the page origin: **200, 236 entries**
- Both `ai-becoming.web.app` and `pratyaksha-3f089.web.app` serve the fixed bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
