### PR TITLE
Serve fresh HTML after deploys (SW + no-cache headers)

### DIFF
--- a/Pratyaksha/dashboard/firebase.ai-becoming.json
+++ b/Pratyaksha/dashboard/firebase.ai-becoming.json
@@ -12,6 +12,18 @@
         "headers": [
           { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
         ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        ]
+      },
+      {
+        "source": "/sw.js",
+        "headers": [
+          { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        ]
       }
     ]
   }

--- a/Pratyaksha/dashboard/firebase.json
+++ b/Pratyaksha/dashboard/firebase.json
@@ -24,6 +24,18 @@
         ]
       },
       {
+        "source": "/index.html",
+        "headers": [
+          { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        ]
+      },
+      {
+        "source": "/sw.js",
+        "headers": [
+          { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        ]
+      },
+      {
         "source": "/**",
         "headers": [
           {

--- a/Pratyaksha/dashboard/public/sw.js
+++ b/Pratyaksha/dashboard/public/sw.js
@@ -1,7 +1,7 @@
 // Becoming Service Worker
-const CACHE_NAME = 'becoming-v2';
-const STATIC_CACHE = 'becoming-static-v2';
-const DYNAMIC_CACHE = 'becoming-dynamic-v2';
+const CACHE_NAME = 'becoming-v3';
+const STATIC_CACHE = 'becoming-static-v3';
+const DYNAMIC_CACHE = 'becoming-dynamic-v3';
 
 // Static assets to cache on install
 const STATIC_ASSETS = [
@@ -55,6 +55,27 @@ self.addEventListener('fetch', (event) => {
 
   // Skip external requests
   if (url.origin !== location.origin) return;
+
+  // Navigation (HTML document) requests: always fetch fresh from the network,
+  // bypassing the browser HTTP cache, so a new deploy's index.html (and the
+  // new hashed asset it references) is picked up immediately instead of being
+  // pinned to a stale bundle for up to an hour. Falls back to cache offline.
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request, { cache: 'reload' })
+        .then((response) => {
+          const clone = response.clone();
+          if (response.ok) {
+            caches.open(DYNAMIC_CACHE).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        })
+        .catch(() =>
+          caches.match(request).then((cached) => cached || caches.match('/'))
+        )
+    );
+    return;
+  }
 
   event.respondWith(
     // Network first strategy


### PR DESCRIPTION
Fixes stale-bundle stickiness after deploys. sw.js (v3) fetches navigation HTML with `cache: 'reload'`; index.html and sw.js are served no-cache. Verified live: v3 SW active on ai-becoming.web.app, newest bundle, 235 real entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)