### PR TITLE
Fix empty replies from GPT-5 reasoning models (Rama/Krishna)

### DIFF
--- a/Pratyaksha/dashboard/server/config/chatModes.ts
+++ b/Pratyaksha/dashboard/server/config/chatModes.ts
@@ -65,7 +65,7 @@ export const CHAT_MODES: Record<ChatModeId, ChatMode> = {
     glyph: "🏹",
     model: "openai/gpt-5-nano",
     temperature: 0.7,
-    maxTokens: 700,
+    maxTokens: 1000,
     karmaCost: 15,
     systemPrompt: `VOICE: Rama — the Steady One (wisdom of the Ramayana).
 You embody dharma (right action), maryādā (honour and healthy boundaries), patience, and equanimity through hardship — the ideal known as Maryādā Puruṣottama. You are the companion for everyday discipline and integrity.
@@ -87,7 +87,7 @@ Scripture repertoire (use rarely, quote accurately): "रघुकुल री�
     glyph: "🪈",
     model: "openai/gpt-5-mini",
     temperature: 0.6,
-    maxTokens: 900,
+    maxTokens: 1200,
     karmaCost: 40,
     systemPrompt: `VOICE: Krishna — the Guide (wisdom of the Bhagavad Gita, from the Mahabharata).
 You embody clarity in the face of paralysis, action without attachment to outcomes (nishkama karma), and the ability to see the larger field. You are the strategist and motivator who helped Arjuna act when he froze.

--- a/Pratyaksha/dashboard/server/lib/openrouter.ts
+++ b/Pratyaksha/dashboard/server/lib/openrouter.ts
@@ -34,6 +34,18 @@ export const MODELS = {
 
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
 
+/**
+ * GPT-5 family models are REASONING models: their completion budget is shared
+ * between hidden reasoning tokens and visible output. With a normal chat budget
+ * the reasoning can consume everything and leave an EMPTY response. Force
+ * reasoning to "minimal" so they behave like fast chat models and actually emit
+ * text. Non-GPT-5 models (e.g. gpt-4o) reject this param, so only add it for
+ * gpt-5*. Returned as modelKwargs so it passes straight through to OpenRouter.
+ */
+function reasoningKwargs(model: string): Record<string, unknown> {
+  return /(^|\/)gpt-5/.test(model) ? { reasoning_effort: "minimal" } : {}
+}
+
 /** Create a ChatOpenAI instance routed through OpenRouter */
 export function getModel(
   modelName: string = MODELS.CHEAP,
@@ -55,6 +67,7 @@ export function getModel(
       },
     },
     apiKey: OPENROUTER_API_KEY,
+    modelKwargs: reasoningKwargs(modelName),
   })
 }
 
@@ -90,7 +103,7 @@ export async function callOpenRouter<T>(
       },
     },
     apiKey: OPENROUTER_API_KEY!,
-    modelKwargs: { response_format: { type: "json_object" } },
+    modelKwargs: { response_format: { type: "json_object" }, ...reasoningKwargs(model) },
   })
 
   const messages: BaseMessage[] = []


### PR DESCRIPTION
gpt-5-nano (Rama) and gpt-5-mini (Krishna) are reasoning models — their completion budget is split between hidden reasoning tokens and visible output. With the chat token cap, reasoning consumed the whole budget and replies came back **empty** (`success:true, response:""`, 2600+ tokens used). gpt-5.6-luna (Shiva) reasons less and was unaffected.

**Fix**
- `openrouter.ts`: add `reasoning_effort:"minimal"` via `modelKwargs` for `gpt-5*` models only (gpt-4o rejects the param), in both `getModel()` and `callOpenRouter()`.
- `chatModes.ts`: bump Rama 700→1000, Krishna 900→1200 output tokens for margin.

**Verified live on the deployed backend (v5):** Rama, Krishna, and Shiva all return real, RAG-grounded, in-voice replies; Krishna correctly quotes Gita 2.47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FN8kcRgY1ArwACuxjcr9eL