### PR TITLE
Owner accounts get unlimited XP

### DIFF
--- a/Pratyaksha/dashboard/src/contexts/KarmaContext.tsx
+++ b/Pratyaksha/dashboard/src/contexts/KarmaContext.tsx
@@ -18,6 +18,7 @@ import {
   isYesterday,
   getSoulMappingProgress,
   shouldAutoGiftKarma,
+  isOwnerUid,
 } from "../lib/gamificationStorage";
 import { toast } from "sonner";
 import { apiFetch } from "@/lib/api";
@@ -30,6 +31,8 @@ type KarmaCost = keyof typeof KARMA_COSTS;
 interface KarmaContextValue {
   // State
   karma: number;
+  /** True for owner/unlimited accounts — no karma is ever charged. */
+  isUnlimited: boolean;
   unlockLevel: UnlockTier;
   completedSoulMappingTopics: string[];
   streakDays: number;
@@ -77,6 +80,9 @@ export function KarmaProvider({ children }: KarmaProviderProps) {
 
   // Load state from localStorage
   const [state, setState] = useState<GamificationState>(() => loadGamificationState());
+
+  // Owner/unlimited accounts bypass all karma costs.
+  const isUnlimited = isOwnerUid(user?.uid);
 
   // Sync entry count from actual entries
   const entryCount = entries.length;
@@ -204,6 +210,8 @@ export function KarmaProvider({ children }: KarmaProviderProps) {
 
   // Spend karma for an action
   const spendKarma = useCallback((cost: KarmaCost): boolean => {
+    if (isUnlimited) return true; // owner: never charged
+
     const amount = KARMA_COSTS[cost];
 
     if (state.karma < amount) {
@@ -216,13 +224,14 @@ export function KarmaProvider({ children }: KarmaProviderProps) {
     }));
 
     return true;
-  }, [state.karma]);
+  }, [state.karma, isUnlimited]);
 
   // Check if user can afford a cost
   const canAfford = useCallback((cost: KarmaCost | number): boolean => {
+    if (isUnlimited) return true; // owner: always affordable
     const amount = typeof cost === "number" ? cost : KARMA_COSTS[cost];
     return state.karma >= amount;
-  }, [state.karma]);
+  }, [state.karma, isUnlimited]);
 
   // Check if a tier is unlocked
   const isTierUnlocked = useCallback((tier: UnlockTier): boolean => {
@@ -387,6 +396,7 @@ export function KarmaProvider({ children }: KarmaProviderProps) {
   const value: KarmaContextValue = {
     // State
     karma: state.karma,
+    isUnlimited,
     unlockLevel,
     completedSoulMappingTopics: state.completedSoulMappingTopics,
     streakDays: state.streakDays,

--- a/Pratyaksha/dashboard/src/lib/gamificationStorage.ts
+++ b/Pratyaksha/dashboard/src/lib/gamificationStorage.ts
@@ -54,6 +54,18 @@ export const KARMA_COSTS = {
   REGENERATE_SUMMARY: 10,      // Weekly/Monthly
 } as const;
 
+// Owner / unlimited accounts: these Firebase UIDs bypass all karma costs
+// (canAfford always true, spendKarma never decrements) and see "∞" XP. Everyone
+// else is metered normally so they can't run up the owner's OpenAI bill on the
+// expensive personas. The gate is client-side only (matches the rest of karma).
+export const OWNER_UIDS: string[] = [
+  "5kI3ZmRHZNNf4OHwqn68lplcUQG3", // yogass09@gmail.com (owner)
+];
+
+export function isOwnerUid(uid?: string | null): boolean {
+  return !!uid && OWNER_UIDS.includes(uid);
+}
+
 // Entry count thresholds for unlocking tiers
 export const UNLOCK_THRESHOLDS = {
   SURFACE: 0,   // Always unlocked

--- a/Pratyaksha/dashboard/src/pages/Chat.tsx
+++ b/Pratyaksha/dashboard/src/pages/Chat.tsx
@@ -22,7 +22,8 @@ export function Chat() {
   const [showFollowUp, setShowFollowUp] = useState(false)
   const [showKarmaDialog, setShowKarmaDialog] = useState(false)
 
-  const { canAfford, spendKarma, karma } = useKarma()
+  const { canAfford, spendKarma, karma, isUnlimited } = useKarma()
+  const karmaDisplay = isUnlimited ? "∞" : `${karma}`
 
   const {
     messages,
@@ -134,7 +135,7 @@ export function Chat() {
           <div className="hidden md:flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-500/10 border border-amber-500/20">
             <Sparkles className="h-3 w-3 text-amber-500 flex-shrink-0" />
             <span className="text-xs font-medium text-amber-600 dark:text-amber-400">
-              {karma} XP
+              {karmaDisplay} XP
             </span>
           </div>
 
@@ -229,7 +230,11 @@ export function Chat() {
       {/* XP cost notice — per active persona */}
       <div className="flex items-center justify-center gap-1.5 py-1.5 border-t bg-amber-500/5 text-xs text-amber-600 dark:text-amber-400">
         <Sparkles className="h-3 w-3" />
-        <span><strong>{activeMeta.label}</strong> costs <strong>{messageCost} XP</strong>/message · You have <strong>{karma} XP</strong></span>
+        <span>{isUnlimited ? (
+          <><strong>{activeMeta.label}</strong> · Unlimited access <strong>∞</strong></>
+        ) : (
+          <><strong>{activeMeta.label}</strong> costs <strong>{messageCost} XP</strong>/message · You have <strong>{karma} XP</strong></>
+        )}</span>
       </div>
 
       {/* Input */}


### PR DESCRIPTION
Owner UIDs (yogass09@gmail.com) bypass all karma costs — canAfford always true, spendKarma never decrements, UI shows ∞. Everyone else metered normally (Rama 15 / Krishna 40 / Shiva 90) so they can't run up the owner's OpenAI bill on Shiva (gpt-5.6-luna). Frontend-only; client builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)