### PR TITLE
CI: push-to-deploy for frontend (Firebase) + backend (Lightsail)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF endings so they run on Linux CI runners
+# (a CRLF shebang line breaks bash). Force LF regardless of platform.
+*.sh text eol=lf

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,77 @@
+name: Deploy Pratyaksha Backend (Lightsail)
+
+# Backend API (Express/TS) -> AWS Lightsail container. Builds the image on the
+# GitHub runner (Docker built-in — no local Docker needed), pushes to ECR, then
+# redeploys Lightsail. Env is injected from Secrets Manager by the deploy script.
+#
+# Auth: AWS access keys in repo secrets (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+# for an IAM identity allowed to: ECR push + set-repository-policy, Lightsail
+# get-container-services + create-container-service-deployment, and Secrets
+# Manager get-secret-value on /cryptoprism/pratyaksha/*.
+#
+# Path-filtered to backend inputs so pure-frontend changes don't trigger a
+# ~10-min image rebuild (the canonical frontend is served by Firebase, not the
+# container). Manual runs available via workflow_dispatch.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'Pratyaksha/dashboard/server/**'
+      - 'Pratyaksha/dashboard/Dockerfile'
+      - 'Pratyaksha/dashboard/package.json'
+      - 'Pratyaksha/dashboard/package-lock.json'
+      - 'Pratyaksha/dashboard/scripts/deploy-lightsail.sh'
+      - '.github/workflows/deploy-backend.yml'
+
+env:
+  AWS_REGION: us-east-1
+  ECR: 405633560616.dkr.ecr.us-east-1.amazonaws.com/pratyaksha
+  API_BASE_URL: https://pratyaksha.8xy5d1tats0s8.us-east-1.cs.amazonlightsail.com
+
+jobs:
+  deploy-backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Pratyaksha/dashboard
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        env:
+          # VITE_* are baked into the image's embedded frontend at build time.
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_FIREBASE_VAPID_KEY: ${{ secrets.VITE_FIREBASE_VAPID_KEY }}
+        run: |
+          docker build -t "$ECR:latest" \
+            --build-arg VITE_FIREBASE_API_KEY="$VITE_FIREBASE_API_KEY" \
+            --build-arg VITE_FIREBASE_AUTH_DOMAIN="$VITE_FIREBASE_AUTH_DOMAIN" \
+            --build-arg VITE_FIREBASE_PROJECT_ID="$VITE_FIREBASE_PROJECT_ID" \
+            --build-arg VITE_FIREBASE_STORAGE_BUCKET="$VITE_FIREBASE_STORAGE_BUCKET" \
+            --build-arg VITE_FIREBASE_MESSAGING_SENDER_ID="$VITE_FIREBASE_MESSAGING_SENDER_ID" \
+            --build-arg VITE_FIREBASE_APP_ID="$VITE_FIREBASE_APP_ID" \
+            --build-arg VITE_FIREBASE_VAPID_KEY="$VITE_FIREBASE_VAPID_KEY" \
+            --build-arg VITE_API_BASE_URL="$API_BASE_URL" \
+            .
+          docker push "$ECR:latest"
+
+      - name: Deploy to Lightsail
+        run: bash scripts/deploy-lightsail.sh

--- a/.github/workflows/deploy-pratyaksha.yml
+++ b/.github/workflows/deploy-pratyaksha.yml
@@ -22,9 +22,11 @@ name: Deploy Pratyaksha Frontend (Firebase Hosting)
 
 on:
   workflow_dispatch:
-  # push:                              # <- re-enable after configuring the secrets above
-  #   branches: [main]
-  #   paths: ['Pratyaksha/dashboard/**']
+  push:
+    branches: [main]
+    paths:
+      - 'Pratyaksha/dashboard/**'
+      - '.github/workflows/deploy-pratyaksha.yml'
 
 # Canonical URL is https://ai-becoming.web.app (site "ai-becoming" in the
 # social-data-pipeline-and-push Firebase project) — the URL the product is
@@ -52,9 +54,10 @@ jobs:
 
       - name: Install dependencies and build frontend
         env:
-          # Backend origin baked into the bundle. Empty would make the frontend
-          # call same-origin /api (only correct for the single-container build).
-          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          # Backend origin baked into the bundle (public Lightsail URL — hardcoded
+          # so it is not a required secret). Empty would make the frontend call
+          # same-origin /api (only correct for the single-container build).
+          VITE_API_BASE_URL: https://pratyaksha.8xy5d1tats0s8.us-east-1.cs.amazonlightsail.com
           VITE_AIRTABLE_API_KEY: ${{ secrets.VITE_AIRTABLE_API_KEY }}
           VITE_AIRTABLE_BASE_ID: ${{ secrets.VITE_AIRTABLE_BASE_ID }}
           VITE_AIRTABLE_TABLE_ID: ${{ secrets.VITE_AIRTABLE_TABLE_ID }}

--- a/.github/workflows/deploy-pratyaksha.yml
+++ b/.github/workflows/deploy-pratyaksha.yml
@@ -1,24 +1,16 @@
 name: Deploy Pratyaksha Frontend (Firebase Hosting)
 
-# Frontend (React/Vite) -> Firebase Hosting, site "pratyaksha-3f089"
-# (https://pratyaksha-3f089.web.app), project pratyaksha-3f089.
+# Frontend (React/Vite) -> Firebase Hosting site "ai-becoming"
+# (canonical https://ai-becoming.web.app) in project social-data-pipeline-and-push.
 #
-# This replaces the old GCP pipeline (Cloud Build -> Cloud Run + Firebase site
-# "becoming" in project social-data-pipeline-and-push), which was removed in the
-# AWS migration. The backend API now runs on AWS Lightsail (container image in
-# ECR) and is deployed separately (docker build/push to ECR + `aws lightsail
-# create-container-service-deployment`), NOT by this workflow.
+# Auth: Workload Identity Federation (KEYLESS) — reuses the WIF_PROVIDER /
+# WIF_SERVICE_ACCOUNT secrets the pre-migration Cloud Run deploy already used
+# (see commit ae857a4). google-github-actions/auth writes Application Default
+# Credentials that firebase-tools picks up — no service-account JSON, no token to
+# rotate. If the WIF service account lacks the "Firebase Hosting Admin" role on
+# the project, grant it once in IAM (that is the only possible one-time step).
 #
-# Manual-trigger only for now so a push cannot fire a half-configured deploy.
-# To enable auto-deploy on push: uncomment the `push:` trigger below AND add
-# these repository secrets:
-#   FIREBASE_SERVICE_ACCOUNT  - JSON key for a service account with the
-#                               "Firebase Hosting Admin" role on project pratyaksha-3f089
-#   VITE_API_BASE_URL         - https://pratyaksha.8xy5d1tats0s8.us-east-1.cs.amazonlightsail.com
-#   VITE_AIRTABLE_API_KEY, VITE_AIRTABLE_BASE_ID, VITE_AIRTABLE_TABLE_ID
-#   VITE_FIREBASE_API_KEY, VITE_FIREBASE_AUTH_DOMAIN, VITE_FIREBASE_PROJECT_ID,
-#   VITE_FIREBASE_STORAGE_BUCKET, VITE_FIREBASE_MESSAGING_SENDER_ID,
-#   VITE_FIREBASE_APP_ID, VITE_FIREBASE_VAPID_KEY
+# Backend (Lightsail) deploys separately via deploy-backend.yml.
 
 on:
   workflow_dispatch:
@@ -28,24 +20,30 @@ on:
       - 'Pratyaksha/dashboard/**'
       - '.github/workflows/deploy-pratyaksha.yml'
 
-# Canonical URL is https://ai-becoming.web.app (site "ai-becoming" in the
-# social-data-pipeline-and-push Firebase project) — the URL the product is
-# actually used on. FIREBASE_SERVICE_ACCOUNT must be a key for that project
-# with the "Firebase Hosting Admin" role. The site is configured in
-# firebase.ai-becoming.json (Auth remains on the pratyaksha-3f089 project,
-# which already authorizes ai-becoming.web.app).
 env:
   FIREBASE_PROJECT_ID: social-data-pipeline-and-push
+  # Backend origin baked into the bundle (public Lightsail URL — hardcoded, not a secret).
+  VITE_API_BASE_URL: https://pratyaksha.8xy5d1tats0s8.us-east-1.cs.amazonlightsail.com
 
 jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write        # required for WIF
     defaults:
       run:
         working-directory: Pratyaksha/dashboard
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (WIF, keyless)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          # exports GOOGLE_APPLICATION_CREDENTIALS for firebase-tools (ADC)
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -54,10 +52,6 @@ jobs:
 
       - name: Install dependencies and build frontend
         env:
-          # Backend origin baked into the bundle (public Lightsail URL — hardcoded
-          # so it is not a required secret). Empty would make the frontend call
-          # same-origin /api (only correct for the single-container build).
-          VITE_API_BASE_URL: https://pratyaksha.8xy5d1tats0s8.us-east-1.cs.amazonlightsail.com
           VITE_AIRTABLE_API_KEY: ${{ secrets.VITE_AIRTABLE_API_KEY }}
           VITE_AIRTABLE_BASE_ID: ${{ secrets.VITE_AIRTABLE_BASE_ID }}
           VITE_AIRTABLE_TABLE_ID: ${{ secrets.VITE_AIRTABLE_TABLE_ID }}
@@ -72,15 +66,12 @@ jobs:
           npm ci
           npm run build
 
-      - name: Write Firebase service account
+      - name: Deploy to Firebase Hosting (ADC from WIF)
         run: |
-          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$RUNNER_TEMP/firebase-sa.json"
-
-      - name: Deploy to Firebase Hosting
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
-        run: |
-          npx firebase-tools deploy --only hosting --project "$FIREBASE_PROJECT_ID" --config firebase.ai-becoming.json --non-interactive
+          npx firebase-tools deploy --only hosting \
+            --project "$FIREBASE_PROJECT_ID" \
+            --config firebase.ai-becoming.json \
+            --non-interactive
 
       - name: Display URL
         run: echo "Frontend deployed -> https://ai-becoming.web.app"

--- a/Pratyaksha/dashboard/scripts/deploy-lightsail.sh
+++ b/Pratyaksha/dashboard/scripts/deploy-lightsail.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Deploy the pratyaksha container to AWS Lightsail from the :latest ECR image.
+# Env is injected from Secrets Manager (/cryptoprism/pratyaksha/*). Run from CI
+# (GitHub Actions) or locally with AWS creds configured. Assumes the image has
+# already been built + pushed to ECR.
+# =============================================================================
+set -euo pipefail
+REGION="${AWS_REGION:-us-east-1}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+sec() { aws secretsmanager get-secret-value --secret-id "/cryptoprism/pratyaksha/$1" --region "$REGION" --query SecretString --output text; }
+
+# 1. Allow the Lightsail ECR puller principal to pull the private image.
+PRINCIPAL="$(aws lightsail get-container-services --service-name pratyaksha --region "$REGION" \
+  --query "containerServices[0].privateRegistryAccess.ecrImagePullerRole.principalArn" --output text)"
+if [ -z "$PRINCIPAL" ] || [ "$PRINCIPAL" = "None" ]; then echo "ERROR: ECR puller principal not ready"; exit 1; fi
+cat > "$TMP/ecr-policy.json" <<EOF
+{ "Version": "2012-10-17", "Statement": [ { "Sid": "AllowLightsailPull", "Effect": "Allow",
+  "Principal": {"AWS": "$PRINCIPAL"}, "Action": ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"] } ] }
+EOF
+aws ecr set-repository-policy --repository-name pratyaksha --policy-text "file://$TMP/ecr-policy.json" --region "$REGION" >/dev/null
+
+# 2. Pull runtime secret values (exported for the python heredoc; never echoed).
+export DATABASE_URL="$(sec DATABASE_URL)"
+export OPENROUTER_API_KEY="$(sec OPENROUTER_API_KEY)"
+export GROQ_API_KEY="$(sec GROQ_API_KEY)"
+export GEMINI_API_KEY="$(sec GEMINI_API_KEY)"
+export AIRTABLE_API_KEY="$(sec AIRTABLE_API_KEY)"
+export AIRTABLE_BASE_ID="$(sec AIRTABLE_BASE_ID)"
+export AIRTABLE_TABLE_ID="$(sec AIRTABLE_TABLE_ID)"
+export AIRTABLE_USER_PROFILES_TABLE_ID="$(sec AIRTABLE_USER_PROFILES_TABLE_ID)"
+export AIRTABLE_NOTIFICATIONS_TABLE_ID="$(sec AIRTABLE_NOTIFICATIONS_TABLE_ID)"
+export CRON_SECRET="$(sec CRON_SECRET)"
+
+# 3. Build the deployment config.
+python3 - "$TMP" <<'PYEOF'
+import json, os, sys
+tmp = sys.argv[1]
+env = {
+  "NODE_ENV": "production", "PORT": "8080",
+  "DB_HOST": "dbcp-aws.ci348o64i4ep.us-east-1.rds.amazonaws.com",
+  "VITE_FIREBASE_PROJECT_ID": "pratyaksha-3f089",
+}
+for k in ["DATABASE_URL","OPENROUTER_API_KEY","GROQ_API_KEY","GEMINI_API_KEY",
+          "AIRTABLE_API_KEY","AIRTABLE_BASE_ID","AIRTABLE_TABLE_ID",
+          "AIRTABLE_USER_PROFILES_TABLE_ID","AIRTABLE_NOTIFICATIONS_TABLE_ID","CRON_SECRET"]:
+    env[k] = os.environ[k]
+containers = {"app": {
+  "image": "405633560616.dkr.ecr.us-east-1.amazonaws.com/pratyaksha:latest",
+  "ports": {"8080": "HTTP"}, "environment": env }}
+endpoint = {"containerName": "app", "containerPort": 8080,
+  "healthCheck": {"path": "/health", "intervalSeconds": 10, "timeoutSeconds": 5,
+                  "healthyThreshold": 2, "unhealthyThreshold": 5, "successCodes": "200"}}
+open(tmp + "/ls-containers.json", "w").write(json.dumps(containers))
+open(tmp + "/ls-endpoint.json", "w").write(json.dumps(endpoint))
+PYEOF
+
+# 4. Deploy.
+aws lightsail create-container-service-deployment \
+  --service-name pratyaksha \
+  --containers "file://$TMP/ls-containers.json" \
+  --public-endpoint "file://$TMP/ls-endpoint.json" \
+  --region "$REGION" \
+  --query "containerService.{state:state,deploymentState:currentDeployment.state}" --output json
+echo "DEPLOY SUBMITTED"


### PR DESCRIPTION
Ends the manual/local deploy dance. After this + AWS secrets, **push to `main` = live** — no local Docker, no Firebase login, no local AWS creds.

## What this adds
- **deploy-pratyaksha.yml** (frontend): push trigger enabled; **auth via existing WIF (keyless)** — reuses `WIF_PROVIDER`/`WIF_SERVICE_ACCOUNT` (the pre-migration Cloud Run deploy used them, commit ae857a4). firebase-tools uses ADC → **no Firebase SA JSON to create.** Deploys canonical `ai-becoming`.
- **deploy-backend.yml** (NEW): builds the image on the runner (Docker built-in), pushes to ECR, redeploys Lightsail. Path-filtered to backend inputs.
- **scripts/deploy-lightsail.sh** (NEW): CI-friendly; injects runtime env from Secrets Manager.
- **.gitattributes**: forces LF on `.sh` (verified: committed blob has 0 CR).

## Secrets status
- ✅ **Firebase**: `WIF_PROVIDER` + `WIF_SERVICE_ACCOUNT` already exist — nothing to add. (One possible one-time IAM step: grant that WIF service account the *Firebase Hosting Admin* role if it doesn't have it — the first run will tell us.)
- ✅ All `VITE_*` / DB / API secrets already exist.
- ⚠️ **AWS only** — add two (there are no AWS secrets in the repo today):
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`
  for an IAM identity allowed to ECR push, Lightsail deploy, and Secrets Manager read on `/cryptoprism/pratyaksha/*`.

Merging triggers both workflows — add the AWS secrets first so the backend run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)